### PR TITLE
BUILD-3882 unarchive sonar-classloader

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/CODEOWNERS @sonarsource/sonarcloud


### PR DESCRIPTION
# BUILD-3882 unarchive sonar-classloader

## Changes
Define sonarcloud team as codeowner of this repository
That way the repository is compliant and will not fail re team nightly checks