### PR TITLE
SC-41037 Fix the Analysis Processing team name in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/CODEOWNERS @sonarsource/orchestration-processing-squad
+.github/CODEOWNERS @sonarsource/quality-processing-squad


### PR DESCRIPTION
## Summary
Update the Github team name in `.github/CODEOWNERS` from `orchestration-processing-squad` to `quality-processing-squad` due to the team's move from the Code Orchestration team to Code Quality.

## Related Jira
- [SC-41026](https://sonarsource.atlassian.net/browse/SC-41026)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SC-41026]: https://sonarsource.atlassian.net/browse/SC-41026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ