### PR TITLE
Change Code Owners and Slack notification

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
-.github/CODEOWNERS @sonarsource/quality-processing-squad
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @sonarsource/code-quality-ci-experience-squad

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,4 +16,4 @@ jobs:
     with:
       publishToBinaries: false
       mavenCentralSync: true
-      slackChannel: build
+      slackChannel: ops-ci-experience


### PR DESCRIPTION
----
## Summary by Gitar

- **Repository configuration:**
  - Updated `.github/CODEOWNERS` to assign the `@sonarsource/code-quality-ci-experience-squad` as owners.
- **CI/CD updates:**
  - Changed the `slackChannel` in `.github/workflows/release.yml` from `build` to `ops-ci-experience`.

<sub>This will update automatically on new commits.</sub>